### PR TITLE
Fix native :fields behavior mismatch with rest

### DIFF
--- a/src/clojurewerkz/elastisch/native/conversion.clj
+++ b/src/clojurewerkz/elastisch/native/conversion.clj
@@ -327,7 +327,7 @@
   (cond
    (instance? java.util.Map fields) (into {} (map (fn [^java.util.Map$Entry e]
                                                     [(keyword (.getKey e))
-                                                     (.. e getValue getValue)]) fields))
+                                                     (.. e getValue getValues)]) fields))
    :else fields))
 
 (defn ^IPersistentMap get-response->map


### PR DESCRIPTION
When processing results from a search query 'convert-fields-result' called getValue instead of getValues. This caused the first of the values to be returned. This behavior is inconsistent with the behavior of the rest api which always returns a vector.
